### PR TITLE
docs: Fix Typo in Image Alt Text for "RedStone Architecture"

### DIFF
--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -42,5 +42,5 @@ RedStone was designed with a modular architecture making it easy to incorporate 
 - RedStone supports leading projects like [Morpho](https://morpho.org/), [Venus](https://venus.io/), and [Pendle Finance](https://www.pendle.finance/).
 
 <a target="_blank" href="https://raw.githubusercontent.com/redstone-finance/redstone-docs/main/static/img/redstone-architecture-simple.png">
-  <img alt="RedStone Architecure" src="/img/redstone-architecture-simple.png"/>
+  <img alt="RedStone Architecture" src="/img/redstone-architecture-simple.png"/>
 </a>


### PR DESCRIPTION
**Description:**

<img width="1068" alt="Снимок экрана 2024-12-04 в 20 55 06" src="https://github.com/user-attachments/assets/a2193732-4c26-491e-a2ec-df2b68c51788">

This update fixes a typo in the alt text of the RedStone architecture image. The word "Architecure" was mistakenly used instead of the correct "Architecture." While this might seem like a small issue, accurate alt text is important for accessibility and SEO. Ensuring that the alt text is correct will improve the user experience, particularly for visually impaired users who rely on screen readers, and help search engines better index the content.

The updated code:

```html
<img alt="RedStone Architecture" src="/img/redstone-architecture-simple.png"/>
```

This small change will enhance both the clarity and professionalism of the content.