### PR TITLE
Contracts are no longer in /dist/

### DIFF
--- a/docs/dapps/redstone-pull.mdx
+++ b/docs/dapps/redstone-pull.mdx
@@ -57,7 +57,7 @@ In foundry project:
 3. Add libraries to `remappings.txt`
 
    ```bash
-   echo "@redstone-finance/evm-connector/dist/contracts/=lib/redstone-oracles-monorepo/packages/evm-connector/contracts/
+   echo "@redstone-finance/evm-connector/contracts/=lib/redstone-oracles-monorepo/packages/evm-connector/contracts/
    @openzeppelin/contracts=lib/openzeppelin-contracts/contracts/" >> remappings.txt
    ```
 


### PR DESCRIPTION
I had to change this path to remove the `dist` to make the remappings work because the contracts it's linking to are no longer in `/dist/`